### PR TITLE
Output of processing pipeline is refactored

### DIFF
--- a/src/main/java/DeepSpaceVision/App.java
+++ b/src/main/java/DeepSpaceVision/App.java
@@ -6,7 +6,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
-import org.opencv.core.RotatedRect;
 
 import DeepSpaceVision.outputs.*;
 import DeepSpaceVision.sources.*;
@@ -67,14 +66,15 @@ public class App {
         for (Output output : outputs)
             Runtime.getRuntime().addShutdownHook(output.new OutputShutdownHook());
 
-        Processor processor = new Processor();
+        TargetData.Factory targetDataFactory = new TargetData.Factory(60.0, source.GetFrameSize().width);
+        Processor processor = new Processor(targetDataFactory);
 
         System.out.println("[MAIN] Starting main loop...");
         while (source.HasMoreFrames() && isRunning.get()) {
             Mat frame = source.Read();
-            RotatedRect[] outData = processor.Process(frame);
+            TargetData outData = processor.Process(frame);
             Mat outFrame = frame;
-            if (outData.length > 0)
+            if (outData != null)
             {
                 outFrame = processor.DrawOutput(frame, outData);  // TODO: Move this somewhere else
                 // System.out.println("First center: " + outData[0].center);

--- a/src/main/java/DeepSpaceVision/Output.java
+++ b/src/main/java/DeepSpaceVision/Output.java
@@ -3,8 +3,9 @@ package DeepSpaceVision;
 import java.io.Closeable;
 import java.io.IOException;
 
+import javax.annotation.Nullable;
+
 import org.opencv.core.Mat;
-import org.opencv.core.RotatedRect;
 
 public abstract class Output implements Closeable {
     public class OutputShutdownHook extends Thread {
@@ -19,6 +20,6 @@ public abstract class Output implements Closeable {
         }
     }
 
-    public abstract void Write(Mat frame, RotatedRect[] data);
+    public abstract void Write(Mat frame, @Nullable TargetData data);
     public abstract void close() throws IOException;
 }

--- a/src/main/java/DeepSpaceVision/Processor.java
+++ b/src/main/java/DeepSpaceVision/Processor.java
@@ -83,6 +83,15 @@ public class Processor {
         // draw midline
         Imgproc.line(output, new Point(data.getCenterX(), 0.0), new Point(data.getCenterX(), output.size().height), new Scalar(255, 0, 0));
 
+        // draw angle
+        Imgproc.putText(output,
+            String.valueOf(data.getAngle()),
+            new Point(data.getCenterX() + 25, 75),
+            Imgproc.FONT_HERSHEY_SIMPLEX,
+            3,
+            new Scalar(255, 255, 255)
+        );
+
         return output;
     }
 

--- a/src/main/java/DeepSpaceVision/TargetData.java
+++ b/src/main/java/DeepSpaceVision/TargetData.java
@@ -1,0 +1,44 @@
+package DeepSpaceVision;
+
+import org.opencv.core.RotatedRect;
+
+public class TargetData {
+    private RotatedRect[] rects;
+    private double centerX;
+    private double angle;
+
+    public TargetData(RotatedRect[] rects, double fov, double frameWidth) {
+        this.rects = rects;
+
+        this.centerX = (rects[0].center.x + rects[1].center.x) / 2.0;
+        
+        double degreesPerPixel = fov / frameWidth;
+        this.angle = (centerX - (frameWidth / 2.0)) * degreesPerPixel;
+    }
+
+    public RotatedRect[] getRects() {
+        return this.rects;
+    }
+
+    public double getCenterX() {
+        return this.centerX;
+    }
+
+    public double getAngle() {
+        return this.angle;
+    }
+
+    public static class Factory {
+        private double fov;
+        private double frameWidth;
+
+        public Factory(double fov, double frameWidth) {
+            this.fov = fov;
+            this.frameWidth = frameWidth;
+        }
+
+        public TargetData createTargetData(RotatedRect[] rects) {
+            return new TargetData(rects, this.fov, this.frameWidth);
+        }
+    }
+}

--- a/src/main/java/DeepSpaceVision/TcpServer.java
+++ b/src/main/java/DeepSpaceVision/TcpServer.java
@@ -4,8 +4,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.LinkedList;
 
-import org.opencv.core.RotatedRect;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -20,7 +18,7 @@ public class TcpServer extends Thread {
     private BufferedReader reader;
     private BufferedWriter writer;
     
-    public LinkedList<RotatedRect[]> dataQueue = new LinkedList<>();
+    public LinkedList<TargetData> dataQueue = new LinkedList<>();
 
     public TcpServer(int port, Runnable onShutdown) {
         this.onShutdown = onShutdown;
@@ -59,9 +57,9 @@ public class TcpServer extends Thread {
                 }
 
                 synchronized (dataQueue) {
-                    RotatedRect[] out = dataQueue.poll();
-                    if (out != null && out.length > 0) {
-                        writer.write(String.valueOf((out[0].center.x + out[1].center.x) / 2.0) + "\n");
+                    TargetData out = dataQueue.poll();
+                    if (out != null) {
+                        writer.write(String.valueOf(out.getAngle()) + "\n");
                         writer.flush();
                     }
                 }

--- a/src/main/java/DeepSpaceVision/outputs/ImageOutput.java
+++ b/src/main/java/DeepSpaceVision/outputs/ImageOutput.java
@@ -1,10 +1,10 @@
 package DeepSpaceVision.outputs;
 
 import org.opencv.core.Mat;
-import org.opencv.core.RotatedRect;
 import org.opencv.imgcodecs.Imgcodecs;
 
 import DeepSpaceVision.Output;
+import DeepSpaceVision.TargetData;
 
 public class ImageOutput extends Output {
     private Mat output;
@@ -15,7 +15,7 @@ public class ImageOutput extends Output {
     }
 
     @Override
-    public void Write(Mat frame, RotatedRect[] data) {
+    public void Write(Mat frame, TargetData data) {
         output = frame;
     }
 

--- a/src/main/java/DeepSpaceVision/outputs/TcpServerOutput.java
+++ b/src/main/java/DeepSpaceVision/outputs/TcpServerOutput.java
@@ -3,9 +3,9 @@ package DeepSpaceVision.outputs;
 import java.io.IOException;
 
 import org.opencv.core.Mat;
-import org.opencv.core.RotatedRect;
 
 import DeepSpaceVision.Output;
+import DeepSpaceVision.TargetData;
 import DeepSpaceVision.TcpServer;
 
 public class TcpServerOutput extends Output {
@@ -17,7 +17,7 @@ public class TcpServerOutput extends Output {
     }
 
     @Override
-    public void Write(Mat frame, RotatedRect[] data) {
+    public void Write(Mat frame, TargetData data) {
         synchronized(serverThread.dataQueue) {
             serverThread.dataQueue.add(data);
         }

--- a/src/main/java/DeepSpaceVision/outputs/VideoOutput.java
+++ b/src/main/java/DeepSpaceVision/outputs/VideoOutput.java
@@ -1,11 +1,11 @@
 package DeepSpaceVision.outputs;
 
 import org.opencv.core.Mat;
-import org.opencv.core.RotatedRect;
 import org.opencv.core.Size;
 import org.opencv.videoio.VideoWriter;
 
 import DeepSpaceVision.Output;
+import DeepSpaceVision.TargetData;
 
 /**
  * Sends processed frames to a video file. This is only guaranteed to work with the .avi file extension.
@@ -19,7 +19,7 @@ public class VideoOutput extends Output {
     }
 
     @Override
-    public void Write(Mat frame, RotatedRect[] data) {
+    public void Write(Mat frame, TargetData data) {
         output.write(frame);
     }
 

--- a/src/test/java/DeepSpaceVision/ProcessorTests.java
+++ b/src/test/java/DeepSpaceVision/ProcessorTests.java
@@ -1,6 +1,7 @@
 package DeepSpaceVision;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -18,6 +19,7 @@ import org.opencv.imgcodecs.Imgcodecs;
 public class ProcessorTests
  {
     private Processor processor;
+    private TargetData.Factory dataFactory;
 
     @BeforeAll
     public static void setUpAll() {
@@ -26,7 +28,8 @@ public class ProcessorTests
 
     @BeforeEach
     public void setUpEach() {
-        processor = new Processor();
+        dataFactory = new TargetData.Factory(60.0, 640);
+        processor = new Processor(dataFactory);
     }
 
     @DisplayName("Should detect two RotatedRects in a valid image")
@@ -38,16 +41,16 @@ public class ProcessorTests
     })
     public void testPositiveDetection(String fname) {
         Mat frame = Imgcodecs.imread(fname);
-        RotatedRect[] outData = processor.Process(frame);
-        assertEquals(2, outData.length, "Failed on " + fname);
+        TargetData outData = processor.Process(frame);
+        assertNotNull(outData, "Failed on " + fname);
     }
 
     @DisplayName("Should not detect any RotatedRects in an invalid image")
     @Test
     public void testNegativeDetection() {
         Mat frame = Imgcodecs.imread("src/test/resources/fail.jpg");
-        RotatedRect[] outData = processor.Process(frame);
-        assertEquals(0, outData.length);
+        TargetData outData = processor.Process(frame);
+        assertNull(outData);
     }
 
     @DisplayName("Should detect RotatedRects with +-10px accuracy")
@@ -59,16 +62,17 @@ public class ProcessorTests
     })
     public void testPositionAccuracy(String fname, int x1, int y1, int x2, int y2) {
         Mat frame = Imgcodecs.imread(fname);
-        RotatedRect[] outData = processor.Process(frame);
+        TargetData outData = processor.Process(frame);
+        RotatedRect[] rects = outData.getRects();
 
-        assertTrue(outData[0].center.x > x1 - 10);
-        assertTrue(outData[0].center.x < x1 + 10);
-        assertTrue(outData[0].center.y > y1 - 10);
-        assertTrue(outData[0].center.y < y1 + 10);
+        assertTrue(rects[0].center.x > x1 - 10);
+        assertTrue(rects[0].center.x < x1 + 10);
+        assertTrue(rects[0].center.y > y1 - 10);
+        assertTrue(rects[0].center.y < y1 + 10);
 
-        assertTrue(outData[1].center.x > x2 - 10);
-        assertTrue(outData[1].center.x < x2 + 10);
-        assertTrue(outData[1].center.y > y2 - 10);
-        assertTrue(outData[1].center.y < y2 + 10);
+        assertTrue(rects[1].center.x > x2 - 10);
+        assertTrue(rects[1].center.x < x2 + 10);
+        assertTrue(rects[1].center.y > y2 - 10);
+        assertTrue(rects[1].center.y < y2 + 10);
     }
 }

--- a/src/test/java/DeepSpaceVision/TcpServerTests.java
+++ b/src/test/java/DeepSpaceVision/TcpServerTests.java
@@ -35,10 +35,18 @@ public class TcpServerTests {
             client = new Socket("localhost", 50000);
             reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
 
-            RotatedRect[] data = new RotatedRect[] {
-                new RotatedRect(),
-                new RotatedRect()
-            };
+            // RotatedRect[] data = new RotatedRect[] {
+            //     new RotatedRect(),
+            //     new RotatedRect()
+            // };
+            TargetData data = new TargetData(
+                new RotatedRect[] {
+                    new RotatedRect(),
+                    new RotatedRect()
+                },
+                60.0,
+                640.0
+            );
             synchronized(serverThread.dataQueue) {
                 serverThread.dataQueue.add(data);
             }
@@ -73,7 +81,7 @@ public class TcpServerTests {
             client = new Socket("localhost", 50001);
             reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
 
-            RotatedRect[] data = new RotatedRect[0];
+            TargetData data = null;
             synchronized(serverThread.dataQueue) {
                 serverThread.dataQueue.add(data);
             }


### PR DESCRIPTION
- Processing pipeline now outputs `TargetData` objects instead of `RotatedRect[]` arrays
  - `TargetData` contains the following data:
    - `RotatedRect[] rects`: used by image annotation and unit tests
    - `double centerX`: used by image annotation
    - `double angle`: used by robot
  - The angle calculations require the camera's horizontal FOV. The application currently uses the hard-coded value 60, since that's the FOV of the Lifecam.
  - The factory class `TargetData.Factory` is used to make gathering frame width from the selected `Source` easier.
- TCP server output now sends the angle to rotate instead of the center X value. This reflects the values actually needed by [the robot code](https://github.com/1777TheVikings/FRC1777-2019-Code/blob/master/src/main/java/frc/robot/vision/JetsonVision.java#L60).
- The angle to the target is drawn on the image annotations.

All tests passed. Fixes #4.